### PR TITLE
Implement errors for CAs and crate methods

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           override: true
           profile: minimal
           target: x86_64-pc-windows-msvc
-          toolchain: stable
+          toolchain: nightly
       - name: Check formatting
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,8 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all
+          # Need to pass --features nightly because  of https://github.com/rust-lang/cargo/issues/2911.
+          args: --all --features nightly
       - name: Set up MSBuild
         uses: microsoft/setup-msbuild@v1.1
       - name: Build example MSI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           override: true
           profile: minimal
           target: x86_64-pc-windows-msvc
-          toolchain: stable
+          toolchain: nightly
       - name: Test
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,8 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all
+          # Need to pass --features nightly because  of https://github.com/rust-lang/cargo/issues/2911.
+          args: --all --features nightly
       - name: Release
         run: gh release create ${{ github.ref_name }} --generate-notes
         env:

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -2,6 +2,7 @@
   "version": "0.2",
   "language": "en",
   "words": [
+    "BUGBUG",
     "cdylib",
     "INSTALLMESSAGE",
     "LANGID",
@@ -11,11 +12,13 @@
     "msica",
     "msiexec",
     "MSIHANDLE",
+    "msvc",
     "PMSIHANDLE",
     "pwsh",
     "repr",
     "rustfmt",
     "rustup",
+    "thiserror",
     "USEREXIT",
     "wixproj"
   ],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "rust-analyzer.cargo.features": "all"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,14 @@ The following software is required:
 
   If Rust is already installed, please run `rustup update` to make sure you're up to date.
 
+* Nightly toolchain
+
+  You need to install the nightly toolchain to build and test all examples.
+
+  ```bash
+  rustup toolchain install nightly
+  ```
+
 The following software is recommended:
 
 * [Visual Studio Code](https://code.visualstudio.com/)
@@ -31,7 +39,7 @@ The following software is recommended:
 To build and test, simply run:
 
 ```powershell
-cargo test --all
+cargo test --all --features nightly
 ```
 
 By default, this will build x64 custom action DLLs from under _examples_.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,17 @@ description = "Rust for Windows Installer Custom Actions"
 homepage = "https://github.com/heaths/msica-rs/"
 repository = "https://github.com/heaths/msica-rs/"
 
+[features]
+default = []
+nightly = []
+
+[dependencies]
+thiserror = "1.0.37"
+
+[package.metadata.docs.rs]
+all-features = true
+default-target = "x86_64-pc-windows-msvc"
+
 [[example]]
 name = "deferred"
 crate-type = ["cdylib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,6 @@ repository = "https://github.com/heaths/msica-rs/"
 default = []
 nightly = []
 
-[dependencies]
-thiserror = "1.0.37"
-
 [package.metadata.docs.rs]
 all-features = true
 default-target = "x86_64-pc-windows-msvc"

--- a/README.md
+++ b/README.md
@@ -16,17 +16,14 @@ You can define custom actions in Rust using its [foreign function interface][ffi
 ```rust
 use msica::*;
 
-const ERROR_SUCCESS: u32 = 0;
-
 #[no_mangle]
-pub extern "C" fn MyCustomAction(session: Session) -> u32 {
+pub extern "C" fn MyCustomAction(session: Session) -> CustomActionResult {
     let record = Record::with_fields(
         Some("this is [1] [2]"),
         vec![Field::IntegerData(1), Field::StringData("example".to_owned())],
-    );
+    )?;
     session.message(MessageType::User, &record);
-
-    ERROR_SUCCESS
+    CustomActionResult::Succeed
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,34 @@ You can define custom actions in Rust using its [foreign function interface][ffi
 ```rust
 use msica::*;
 
+const ERROR_SUCCESS: u32 = 0;
+const ERROR_INSTALL_FAILURE: u32 = 1603;
+
+#[no_mangle]
+pub extern "C" fn MyCustomAction(session: Session) -> u32 {
+    match Record::with_fields(
+        Some("this is [1] [2]"),
+        vec![
+            Field::IntegerData(1),
+            Field::StringData("example".to_owned()),
+        ],
+    ) {
+        Ok(record) => {
+            session.message(MessageType::User, &record);
+            ERROR_SUCCESS
+        }
+        _ => ERROR_INSTALL_FAILURE,
+    }
+}
+```
+
+### Using nightly feature
+
+If you enable the `nightly` feature, you can use the question mark operator (`?`) to propagate errors:
+
+```rust
+use msica::*;
+
 #[no_mangle]
 pub extern "C" fn MyCustomAction(session: Session) -> CustomActionResult {
     let record = Record::with_fields(

--- a/examples/deferred/lib.rs
+++ b/examples/deferred/lib.rs
@@ -19,7 +19,8 @@ pub extern "C" fn DeferredExampleCustomAction(session: Session) -> u32 {
                 Field::IntegerData(100),
                 Field::StringData("last".to_string()),
             ],
-        ),
+        )
+        .unwrap(),
     );
 
     // Schedule custom actions for each row.
@@ -28,7 +29,7 @@ pub extern "C" fn DeferredExampleCustomAction(session: Session) -> u32 {
         let data = format!(
             "{}\t{}",
             record.integer_data(1).unwrap(),
-            record.string_data(2)
+            record.string_data(2).unwrap(),
         );
         session.do_deferred_action("DeferredExampleCustomActionDeferred", &data);
     }
@@ -39,7 +40,7 @@ pub extern "C" fn DeferredExampleCustomAction(session: Session) -> u32 {
 pub extern "C" fn DeferredExampleCustomActionDeferred(session: Session) -> u32 {
     // Process the custom action data passed by the immediate custom action.
     // This data is always made available in a property named "CustomActionData".
-    let data = session.property("CustomActionData");
+    let data = session.property("CustomActionData").unwrap();
     let fields: Vec<&str> = data.split('\t').collect();
     let record = Record::with_fields(
         Some("Running the [2] ([1]) deferred custom action"),
@@ -47,7 +48,8 @@ pub extern "C" fn DeferredExampleCustomActionDeferred(session: Session) -> u32 {
             Field::StringData(fields[0].to_string()),
             Field::StringData(fields[1].to_string()),
         ],
-    );
+    )
+    .unwrap();
     session.message(MessageType::Info, &record);
     ERROR_SUCCESS
 }

--- a/examples/deferred/lib.rs
+++ b/examples/deferred/lib.rs
@@ -1,14 +1,14 @@
 // Copyright 2022 Heath Stewart.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
+use msica::CustomActionResult::Succeed;
 use msica::*;
-const ERROR_SUCCESS: u32 = 0;
 
 #[no_mangle]
-pub extern "C" fn DeferredExampleCustomAction(session: Session) -> u32 {
+pub extern "C" fn DeferredExampleCustomAction(session: Session) -> CustomActionResult {
     let database = session.database();
     let view = database
-        .open_view("SELECT `Cardinal`, `Ordinal` FROM `DeferredExample` ORDER BY `Cardinal`");
+        .open_view("SELECT `Cardinal`, `Ordinal` FROM `DeferredExample` ORDER BY `Cardinal`")?;
 
     // Add another row.
     view.modify(
@@ -19,28 +19,27 @@ pub extern "C" fn DeferredExampleCustomAction(session: Session) -> u32 {
                 Field::IntegerData(100),
                 Field::StringData("last".to_string()),
             ],
-        )
-        .unwrap(),
-    );
+        )?,
+    )?;
 
     // Schedule custom actions for each row.
-    view.execute(None);
+    view.execute(None)?;
     for record in view {
         let data = format!(
             "{}\t{}",
-            record.integer_data(1).unwrap(),
-            record.string_data(2).unwrap(),
+            record.integer_data(1).unwrap_or(0),
+            record.string_data(2)?,
         );
-        session.do_deferred_action("DeferredExampleCustomActionDeferred", &data);
+        session.do_deferred_action("DeferredExampleCustomActionDeferred", &data)?;
     }
-    ERROR_SUCCESS
+    Succeed
 }
 
 #[no_mangle]
-pub extern "C" fn DeferredExampleCustomActionDeferred(session: Session) -> u32 {
+pub extern "C" fn DeferredExampleCustomActionDeferred(session: Session) -> CustomActionResult {
     // Process the custom action data passed by the immediate custom action.
     // This data is always made available in a property named "CustomActionData".
-    let data = session.property("CustomActionData").unwrap();
+    let data = session.property("CustomActionData")?;
     let fields: Vec<&str> = data.split('\t').collect();
     let record = Record::with_fields(
         Some("Running the [2] ([1]) deferred custom action"),
@@ -48,8 +47,7 @@ pub extern "C" fn DeferredExampleCustomActionDeferred(session: Session) -> u32 {
             Field::StringData(fields[0].to_string()),
             Field::StringData(fields[1].to_string()),
         ],
-    )
-    .unwrap();
+    )?;
     session.message(MessageType::Info, &record);
-    ERROR_SUCCESS
+    Succeed
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,4 +2,5 @@
 # Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
 [toolchain]
+channel = "nightly"
 targets = ["x86_64-pc-windows-msvc"]

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,8 +1,8 @@
 // Copyright 2022 Heath Stewart.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
-use super::ffi;
-use super::{Record, View};
+use crate::ffi;
+use crate::{Record, View};
 use std::ffi::CString;
 
 /// The database for the current install session.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,130 @@
+// Copyright 2022 Heath Stewart.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+use thiserror::Error;
+
+use crate::Record;
+
+/// Errors returned by this crate.
+#[derive(Error, Debug)]
+pub enum Error {
+    /// A Windows error code returned from installer functions.
+    #[error("error code {0}")]
+    ErrorCode(u32),
+
+    /// An error [`Record`] containing more information.
+    #[error("installer error: {0}")]
+    ErrorRecord(Record),
+
+    /// A possible error value when converting a `String` from a UTF-8 byte vector.
+    #[error(transparent)]
+    FromUtf8Error(#[from] std::string::FromUtf8Error),
+}
+
+/// Results returned by this crate.
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[cfg(feature = "nightly")]
+pub mod experimental {
+    use crate::ffi;
+    use std::fmt::Display;
+    use std::num::NonZeroU32;
+    use std::ops::{ControlFlow, FromResidual, Try};
+
+    /// A result to return from a custom action.
+    ///
+    /// This allows you to use the `?` operator to map any `Result<T, E>` to [`CustomActionResult::Fail`].
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use std::ffi::OsString;
+    /// use msica::{Session, experimental::CustomActionResult};
+    ///
+    /// #[no_mangle]
+    /// pub extern "C" fn MyCustomAction(h: MSIHANDLE) -> CustomActionResult {
+    ///     let session = Session::from(h);
+    ///     let s = OsString::from("hopefully some properly UTF8-encoded string")?;
+    ///
+    ///     // Do something with `s`.
+    ///
+    ///     CustomActionResult::Succeed
+    /// }
+    /// ```
+    #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+    #[repr(u32)]
+    pub enum CustomActionResult {
+        /// Completed actions successfully.
+        Succeed = ffi::ERROR_SUCCESS,
+
+        /// Skip remaining actions.Not an error.
+        Skip = ffi::ERROR_NO_MORE_ITEMS,
+
+        /// User terminated prematurely.
+        Cancel = ffi::ERROR_INSTALL_USEREXIT,
+
+        /// Unrecoverable error occurred.
+        Fail = ffi::ERROR_INSTALL_FAILURE,
+
+        /// Action not executed.
+        NotExecuted = ffi::ERROR_FUNCTION_NOT_CALLED,
+    }
+
+    impl Display for CustomActionResult {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            let error = match &self {
+                Self::Succeed => "succeeded",
+                Self::Skip => "skip remaining actions",
+                Self::Cancel => "user canceled",
+                Self::Fail => "failed",
+                Self::NotExecuted => "not executed",
+            };
+
+            write!(f, "{}", error)
+        }
+    }
+
+    impl Into<u32> for CustomActionResult {
+        fn into(self) -> u32 {
+            self as u32
+        }
+    }
+
+    /// This type is an implementation detail and not intended for direct use.
+    #[doc(hidden)]
+    pub struct CustomActionResultCode(NonZeroU32);
+
+    impl From<CustomActionResult> for CustomActionResultCode {
+        fn from(value: CustomActionResult) -> Self {
+            CustomActionResultCode(NonZeroU32::new(value.into()).unwrap())
+        }
+    }
+
+    impl Try for CustomActionResult {
+        type Output = u32;
+        type Residual = CustomActionResultCode;
+
+        fn branch(self) -> ControlFlow<Self::Residual, Self::Output> {
+            match self {
+                Self::Succeed => ControlFlow::Continue(ffi::ERROR_SUCCESS),
+                _ => ControlFlow::Break(self.into()),
+            }
+        }
+
+        fn from_output(_: Self::Output) -> Self {
+            CustomActionResult::Succeed
+        }
+    }
+
+    impl FromResidual for CustomActionResult {
+        fn from_residual(residual: <Self as Try>::Residual) -> Self {
+            match residual.0.into() {
+                ffi::ERROR_NO_MORE_ITEMS => CustomActionResult::Skip,
+                ffi::ERROR_INSTALL_USEREXIT => CustomActionResult::Cancel,
+                ffi::ERROR_INSTALL_FAILURE => CustomActionResult::Fail,
+                ffi::ERROR_FUNCTION_NOT_CALLED => CustomActionResult::NotExecuted,
+                code => panic!("unexpected result code {}", code),
+            }
+        }
+    }
+}

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -3,7 +3,7 @@
 
 use crate::ModifyMode;
 
-use super::{MessageType, RunMode};
+use crate::{MessageType, RunMode};
 use std::{
     fmt::Display,
     ops::{Deref, Not},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 
 #![allow(dead_code)]
 #![doc = include_str!("../README.md")]
+#![cfg_attr(feature = "nightly", feature(try_trait_v2))]
 
 // Fail fast on non-Windows platforms.
 #[cfg(not(target_os = "windows"))]
@@ -11,19 +12,19 @@ compile_error!("supported on windows only");
 // See https://docs.microsoft.com/windows/win32/msi/automation-interface-reference
 
 mod database;
+mod errors;
 mod ffi;
 mod record;
 mod session;
 mod view;
 
 pub use database::Database;
-pub use ffi::{
-    ERROR_FUNCTION_NOT_CALLED, ERROR_INSTALL_FAILURE, ERROR_INSTALL_USEREXIT, ERROR_NO_MORE_ITEMS,
-    ERROR_SUCCESS,
-};
+#[cfg(feature = "nightly")]
+pub use errors::experimental::CustomActionResult;
+pub use errors::{Error, Result};
 pub use record::{Field, Record};
-pub use session::Session;
-pub use view::View;
+pub use session::{RunMode, Session};
+pub use view::{ModifyMode, View};
 
 /// Message types that can be processed by a custom action.
 #[repr(u32)]
@@ -36,85 +37,6 @@ pub enum MessageType {
     CommonData = 0x0b00_0000,
 }
 
-#[repr(u32)]
-pub enum ModifyMode {
-    /// Refreshes the information in the supplied record without changing the position in the result set and without affecting subsequent fetch operations.
-    /// The record may then be used for subsequent Update, Delete, and Refresh. All primary key columns of the table must be in the query and the record must have at least as many fields as the query.
-    /// Seek cannot be used with multi-table queries. This mode cannot be used with a view containing joins.
-    Seek = u32::MAX,
-
-    /// Refreshes the information in the record. Must first call `fetch` on [`View`] with the same record.
-    /// Fails for a deleted row. Works with read-write and read-only records.
-    Refresh = 0,
-
-    /// Inserts a record. Fails if a row with the same primary keys exists. Fails with a read-only database.
-    /// This mode cannot be used with a view containing joins.
-    Insert = 1,
-
-    /// Updates an existing record. Nonprimary keys only. Must first call `fetch` on [`View`].
-    /// Fails with a deleted record. Works only with read-write records.
-    Update = 2,
-
-    /// Writes current data in the cursor to a table row. Updates record if the primary keys match an existing row and inserts if they do not match.
-    /// Fails with a read-only database. This mode cannot be used with a view containing joins.
-    Assign = 3,
-
-    /// Updates or deletes and inserts a record into a table. Must first call `fetch` on [`View`] with the same record.
-    /// Updates record if the primary keys are unchanged. Deletes old row and inserts new if primary keys have changed. Fails with a read-only database.
-    /// This mode cannot be used with a view containing joins.
-    Replace = 4,
-
-    /// Inserts or validates a record in a table. Inserts if primary keys do not match any row and validates if there is a match.
-    /// Fails if the record does not match the data in the table. Fails if there is a record with a duplicate key that is not identical. Works only with read-write records.
-    /// This mode cannot be used with a view containing joins.
-    Merge = 5,
-
-    /// Remove a row from the table. You must first call the `fetch` on [`View`] function with the same record.
-    /// Fails if the row has been deleted. Works only with read-write records. This mode cannot be used with a view containing joins.
-    Delete = 6,
-
-    /// Inserts a temporary record. The information is not persistent. Fails if a row with the same primary key exists.
-    /// Works only with read-write records. This mode cannot be used with a view containing joins.
-    InsertTemporary = 7,
-}
-
-/// Run modes passed to `Session::mode`.
-#[repr(u32)]
-pub enum RunMode {
-    /// Administrative mode install, else product install.
-    Admin = 0,
-    /// Advertise mode of install.
-    Advertise = 1,
-    ///Maintenance mode database loaded.
-    Maintenance = 2,
-    /// Rollback is enabled.
-    RollbackEnabled = 3,
-    /// Log file is active.
-    LogEnabled = 4,
-    /// Executing or spooling operations.
-    Operations = 5,
-    /// Reboot is needed.
-    RebootAtEnd = 6,
-    /// Reboot is needed to continue installation
-    RebootNow = 7,
-    /// Installing files from cabinets and files using Media table.
-    Cabinet = 8,
-    /// Source files use only short file names.
-    SourceShortNames = 9,
-    /// Target files are to use only short file names.
-    TargetShortNames = 10,
-    /// Operating system is Windows 98/95.
-    Windows9x = 12,
-    /// Operating system supports advertising of products.
-    ZawEnabled = 13,
-    /// Deferred custom action called from install script execution.
-    Scheduled = 16,
-    /// Deferred custom action called from rollback execution script.
-    Rollback = 17,
-    /// Deferred custom action called from commit execution script.
-    Commit = 18,
-}
-
 /// Gets the last Windows Installer error for the current process.
 ///
 /// # Example
@@ -123,7 +45,7 @@ pub enum RunMode {
 /// use msica::*;
 ///
 /// if let Some(error) = last_error_record() {
-///     println!("last error: {}", error.format_text());
+///     println!("last error: {}", error.format_text().unwrap());
 /// }
 /// ```
 pub fn last_error_record<'a>() -> Option<Record> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,9 @@
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
 #![allow(dead_code)]
-#![doc = include_str!("../README.md")]
+#![cfg_attr(doc, feature(nightly))]
 #![cfg_attr(feature = "nightly", feature(try_trait_v2))]
+#![doc = include_str!("../README.md")]
 
 // Fail fast on non-Windows platforms.
 #[cfg(not(target_os = "windows"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
 #![allow(dead_code)]
-#![cfg_attr(doc, feature(nightly))]
 #![cfg_attr(feature = "nightly", feature(try_trait_v2))]
 #![doc = include_str!("../README.md")]
 
@@ -11,6 +10,7 @@
 compile_error!("supported on windows only");
 
 // See https://docs.microsoft.com/windows/win32/msi/automation-interface-reference
+// for inspiration for the shape of this API.
 
 mod database;
 mod errors;
@@ -24,19 +24,8 @@ pub use database::Database;
 pub use errors::experimental::CustomActionResult;
 pub use errors::{Error, Result};
 pub use record::{Field, Record};
-pub use session::{RunMode, Session};
+pub use session::{MessageType, RunMode, Session};
 pub use view::{ModifyMode, View};
-
-/// Message types that can be processed by a custom action.
-#[repr(u32)]
-pub enum MessageType {
-    Error = 0x0100_0000,
-    Warning = 0x0200_0000,
-    User = 0x0300_0000,
-    Info = 0x0400_0000,
-    Progress = 0x0a00_0000,
-    CommonData = 0x0b00_0000,
-}
 
 /// Gets the last Windows Installer error for the current process.
 ///

--- a/src/record.rs
+++ b/src/record.rs
@@ -46,28 +46,29 @@ impl Record {
     ///
     /// let record = Record::with_fields(
     ///     Some("this is [1] [2]"),
-    ///     vec![Field::IntegerData(1), Field::StringData("example".to_owned())]);
+    ///     vec![Field::IntegerData(1), Field::StringData("example".to_owned())],
+    /// ).expect("failed to create record");
     /// assert_eq!(record.field_count(), 2);
     /// ```
-    pub fn with_fields(text: Option<&str>, fields: Vec<Field>) -> Self {
+    pub fn with_fields(text: Option<&str>, fields: Vec<Field>) -> Result<Self> {
         unsafe {
             let h = ffi::MsiCreateRecord(fields.len() as u32);
             let record = Record { h: h.to_owned() };
 
             if let Some(text) = text {
-                record.set_string_data(0, Some(text));
+                record.set_string_data(0, Some(text))?;
             }
 
             for (i, field) in fields.iter().enumerate() {
                 let i: u32 = i.try_into().unwrap();
                 match field {
-                    Field::StringData(data) => record.set_string_data(i + 1, Some(data)),
-                    Field::IntegerData(data) => record.set_integer_data(i + 1, *data),
+                    Field::StringData(data) => record.set_string_data(i + 1, Some(data))?,
+                    Field::IntegerData(data) => record.set_integer_data(i + 1, *data)?,
                     Field::Null => {}
                 }
             }
 
-            record
+            Ok(record)
         }
     }
 
@@ -92,8 +93,8 @@ impl Record {
     /// let record = Record::with_fields(
     ///     Some("this is [1] [2]{ without [3]}"),
     ///     vec![Field::IntegerData(1), Field::StringData("example".to_owned()), Field::Null],
-    /// );
-    /// assert_eq!(record.format_text().unwrap(), "this is 1 example");
+    /// ).expect("failed to create record");
+    /// assert_eq!(record.format_text().expect("failed to format record"), "this is 1 example");
     /// ```
     pub fn format_text(&self) -> Result<String> {
         unsafe {
@@ -107,7 +108,7 @@ impl Record {
                 &mut value_len as *mut u32,
             );
             if ret != ffi::ERROR_MORE_DATA {
-                return Err(Error::ErrorCode(ret));
+                return Err(Error::from_error_code(ret));
             }
 
             let mut value_len = value_len + 1u32;
@@ -120,7 +121,7 @@ impl Record {
                 &mut value_len as *mut u32,
             );
             if ret != ffi::ERROR_SUCCESS {
-                return Err(Error::ErrorCode(ret));
+                return Err(Error::from_error_code(ret));
             }
 
             value.truncate(value_len as usize);
@@ -142,36 +143,41 @@ impl Record {
     /// let record = Record::with_fields(
     ///     Some("this is [1] [2]"),
     ///     vec![Field::IntegerData(1), Field::StringData("example".to_owned())],
-    /// );
-    /// assert_eq!(record.string_data(2), "example");
+    /// ).expect("failed to create record");
+    /// assert_eq!(record.string_data(2).expect("failed to get field data"), "example");
     /// ```
-    pub fn string_data(&self, field: u32) -> String {
+    pub fn string_data(&self, field: u32) -> Result<String> {
         unsafe {
             let mut value_len = 0u32;
             let value = CString::default();
 
-            if ffi::MsiRecordGetString(
+            let mut ret = ffi::MsiRecordGetString(
                 *self.h,
                 field,
                 value.as_ptr() as ffi::LPSTR,
                 &mut value_len as *mut u32,
-            ) == ffi::ERROR_MORE_DATA
-            {
-                let mut value_len = value_len + 1u32;
-                let mut value: Vec<u8> = vec![0; value_len as usize];
-
-                ffi::MsiRecordGetString(
-                    *self.h,
-                    field,
-                    value.as_mut_ptr() as ffi::LPSTR,
-                    &mut value_len as *mut u32,
-                );
-
-                value.truncate(value_len as usize);
-                return String::from_utf8(value).unwrap();
+            );
+            if ret != ffi::ERROR_MORE_DATA {
+                return Err(Error::from_error_code(ret));
             }
 
-            String::default()
+            let mut value_len = value_len + 1u32;
+            let mut value: Vec<u8> = vec![0; value_len as usize];
+
+            ret = ffi::MsiRecordGetString(
+                *self.h,
+                field,
+                value.as_mut_ptr() as ffi::LPSTR,
+                &mut value_len as *mut u32,
+            );
+            if ret != ffi::ERROR_SUCCESS {
+                return Err(Error::from_error_code(ret));
+            }
+
+            value.truncate(value_len as usize);
+            let text = String::from_utf8(value)?;
+
+            Ok(text)
         }
     }
 
@@ -185,17 +191,23 @@ impl Record {
     /// use msica::{Field, Record};
     ///
     /// let mut record = Record::new(1);
-    /// record.set_string_data(1, Some("example"));
-    /// assert_eq!(record.string_data(1), "example");
+    /// record.set_string_data(1, Some("example")).expect("failed to set field data");
+    /// assert_eq!(record.string_data(1).expect("failed to get field data"), "example");
     /// ```
-    pub fn set_string_data(&self, field: u32, value: Option<&str>) {
+    pub fn set_string_data(&self, field: u32, value: Option<&str>) -> Result<()> {
         unsafe {
             // TODO: Return result containing NulError if returned.
             let value = match value {
-                Some(s) => CString::new(s).unwrap(),
+                Some(s) => CString::new(s)?,
                 None => CString::default(),
             };
-            ffi::MsiRecordSetString(*self.h, field, value.as_ptr());
+
+            let ret = ffi::MsiRecordSetString(*self.h, field, value.as_ptr());
+            if ret != ffi::ERROR_SUCCESS {
+                return Err(Error::from_error_code(ret));
+            }
+
+            Ok(())
         }
     }
 
@@ -211,7 +223,7 @@ impl Record {
     /// let record = Record::with_fields(
     ///     Some("this is [1] [2]"),
     ///     vec![Field::IntegerData(1), Field::StringData("example".to_owned())],
-    /// );
+    /// ).expect("failed to create record");
     /// assert_eq!(record.integer_data(1), Some(1));
     /// ```
     pub fn integer_data(&self, field: u32) -> Option<i32> {
@@ -233,12 +245,17 @@ impl Record {
     /// use msica::{Field, Record};
     ///
     /// let mut record = Record::new(1);
-    /// record.set_integer_data(1, 42);
+    /// record.set_integer_data(1, 42).expect("failed to set field data");
     /// assert_eq!(record.integer_data(1), Some(42));
     /// ```
-    pub fn set_integer_data(&self, field: u32, value: i32) {
+    pub fn set_integer_data(&self, field: u32, value: i32) -> Result<()> {
         unsafe {
-            ffi::MsiRecordSetInteger(*self.h, field, value);
+            let ret = ffi::MsiRecordSetInteger(*self.h, field, value);
+            if ret != ffi::ERROR_SUCCESS {
+                return Err(Error::from_error_code(ret));
+            }
+
+            Ok(())
         }
     }
 
@@ -299,32 +316,37 @@ impl Display for Record {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Result;
 
     #[test]
-    fn from_str() {
+    fn from_str() -> Result<()> {
         let record = Record::from("test");
-        assert_eq!(record.string_data(0), "test");
+        assert_eq!(record.string_data(0)?, "test");
+        Ok(())
     }
 
     #[test]
-    fn from_string() {
+    fn from_string() -> Result<()> {
         let record = Record::from("test".to_owned());
-        assert_eq!(record.string_data(0), "test");
+        assert_eq!(record.string_data(0)?, "test");
+        Ok(())
     }
 
     #[test]
-    fn set_string_data_null() {
-        let record = Record::with_fields(None, vec![Field::StringData("test".to_owned())]);
-        assert_eq!(record.string_data(1), "test");
+    fn set_string_data_null() -> Result<()> {
+        let record = Record::with_fields(None, vec![Field::StringData("test".to_owned())])?;
+        assert_eq!(record.string_data(1)?, "test");
 
-        record.set_string_data(1, None);
+        record.set_string_data(1, None)?;
         assert!(record.is_null(1));
-        assert_eq!(record.string_data(1), "");
+        assert_eq!(record.string_data(1)?, "");
+        Ok(())
     }
 
     #[test]
-    fn integer_data_from_string() {
-        let record = Record::with_fields(None, vec![Field::StringData("test".to_owned())]);
+    fn integer_data_from_string() -> Result<()> {
+        let record = Record::with_fields(None, vec![Field::StringData("test".to_owned())])?;
         assert_eq!(record.integer_data(1), None);
+        Ok(())
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
 use crate::ffi;
-use crate::{Database, Error, MessageType, Record, Result};
+use crate::{Database, Error, Record, Result};
 use std::ffi::CString;
 
 /// A Windows Installer session passed as an [`MSIHANDLE`] to custom actions.
@@ -41,13 +41,18 @@ impl Session {
     ///
     /// To schedule a deferred custom action with its `CustomActionData`,
     /// call `do_deferred_action`.
-    pub fn do_action(&self, action: Option<&str>) {
+    pub fn do_action(&self, action: Option<&str>) -> Result<()> {
         unsafe {
             let action = match action {
-                Some(s) => CString::new(s).unwrap(),
+                Some(s) => CString::new(s)?,
                 None => CString::default(),
             };
-            ffi::MsiDoAction(self.h, action.as_ptr());
+            let ret = ffi::MsiDoAction(self.h, action.as_ptr());
+            if ret != ffi::ERROR_SUCCESS {
+                return Err(Error::from_error_code(ret));
+            }
+
+            Ok(())
         }
     }
 
@@ -62,7 +67,7 @@ impl Session {
     /// #[no_mangle]
     /// pub extern "C" fn MyCustomAction(session: Session) -> u32 {
     ///     for i in 0..5 {
-    ///         session.do_deferred_action("MyDeferredCustomAction", &i.to_string())
+    ///         session.do_deferred_action("MyDeferredCustomAction", &i.to_string());
     ///     }
     ///     ERROR_SUCCESS
     /// }
@@ -70,14 +75,14 @@ impl Session {
     /// #[no_mangle]
     /// pub extern "C" fn MyDeferredCustomAction(session: Session) -> u32 {
     ///     let data = session.property("CustomActionData").expect("failed to get CustomActionData");
-    ///     let record = Record::from(data);
+    ///     let record = Record::try_from(data).expect("failed to create record");
     ///     session.message(MessageType::Info, &record);
     ///     ERROR_SUCCESS
     /// }
     /// ```
-    pub fn do_deferred_action(&self, action: &str, custom_action_data: &str) {
-        self.set_property(action, Some(custom_action_data));
-        self.do_action(Some(action));
+    pub fn do_deferred_action(&self, action: &str, custom_action_data: &str) -> Result<()> {
+        self.set_property(action, Some(custom_action_data))?;
+        self.do_action(Some(action))
     }
 
     /// The numeric language ID used by the current install session.
@@ -155,21 +160,37 @@ impl Session {
     }
 
     /// Sets the value of the named property. Pass `None` to clear the field.
-    pub fn set_property(&self, name: &str, value: Option<&str>) {
+    pub fn set_property(&self, name: &str, value: Option<&str>) -> Result<()> {
         unsafe {
-            let name = CString::new(name).unwrap();
+            let name = CString::new(name)?;
             let value = match value {
-                Some(s) => CString::new(s).unwrap(),
+                Some(s) => CString::new(s)?,
                 None => CString::default(),
             };
 
-            ffi::MsiSetProperty(
+            let ret = ffi::MsiSetProperty(
                 self.h,
                 name.as_ptr() as ffi::LPCSTR,
                 value.as_ptr() as ffi::LPCSTR,
             );
+            if ret != ffi::ERROR_SUCCESS {
+                return Err(Error::from_error_code(ret));
+            }
+
+            Ok(())
         }
     }
+}
+
+/// Message types that can be processed by a custom action.
+#[repr(u32)]
+pub enum MessageType {
+    Error = 0x0100_0000,
+    Warning = 0x0200_0000,
+    User = 0x0300_0000,
+    Info = 0x0400_0000,
+    Progress = 0x0a00_0000,
+    CommonData = 0x0b00_0000,
 }
 
 /// Run modes passed to `Session::mode`.

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,8 +1,8 @@
 // Copyright 2022 Heath Stewart.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
-use super::ffi;
-use super::{Database, MessageType, Record, RunMode};
+use crate::ffi;
+use crate::{Database, MessageType, Record};
 use std::ffi::CString;
 
 /// A Windows Installer session passed as an [`MSIHANDLE`] to custom actions.
@@ -99,6 +99,7 @@ impl Session {
     ///
     /// ```no_run
     /// use msica::*;
+    /// const ERROR_SUCCESS: u32 = 0;
     ///
     /// #[no_mangle]
     /// pub extern "C" fn MyCustomAction(session: Session) -> u32 {
@@ -166,4 +167,41 @@ impl Session {
             );
         }
     }
+}
+
+/// Run modes passed to `Session::mode`.
+#[repr(u32)]
+pub enum RunMode {
+    /// Administrative mode install, else product install.
+    Admin = 0,
+    /// Advertise mode of install.
+    Advertise = 1,
+    ///Maintenance mode database loaded.
+    Maintenance = 2,
+    /// Rollback is enabled.
+    RollbackEnabled = 3,
+    /// Log file is active.
+    LogEnabled = 4,
+    /// Executing or spooling operations.
+    Operations = 5,
+    /// Reboot is needed.
+    RebootAtEnd = 6,
+    /// Reboot is needed to continue installation
+    RebootNow = 7,
+    /// Installing files from cabinets and files using Media table.
+    Cabinet = 8,
+    /// Source files use only short file names.
+    SourceShortNames = 9,
+    /// Target files are to use only short file names.
+    TargetShortNames = 10,
+    /// Operating system is Windows 98/95.
+    Windows9x = 12,
+    /// Operating system supports advertising of products.
+    ZawEnabled = 13,
+    /// Deferred custom action called from install script execution.
+    Scheduled = 16,
+    /// Deferred custom action called from rollback execution script.
+    Rollback = 17,
+    /// Deferred custom action called from commit execution script.
+    Commit = 18,
 }

--- a/src/view.rs
+++ b/src/view.rs
@@ -1,8 +1,11 @@
 // Copyright 2022 Heath Stewart.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
-use super::ffi;
-use super::{ModifyMode, Record};
+use crate::ffi;
+use crate::Record;
+
+#[cfg(doc)]
+use crate::Database;
 
 /// The `View` object represents a result set obtained when processing a query
 /// using the `OpenView` method of the [`Database`] object. Before any data can be transferred,
@@ -78,4 +81,47 @@ impl Iterator for View {
             Some(Record::from_handle(h))
         }
     }
+}
+
+/// Modify modes passed to `View::modify`.
+#[repr(u32)]
+pub enum ModifyMode {
+    /// Refreshes the information in the supplied record without changing the position in the result set and without affecting subsequent fetch operations.
+    /// The record may then be used for subsequent Update, Delete, and Refresh. All primary key columns of the table must be in the query and the record must have at least as many fields as the query.
+    /// Seek cannot be used with multi-table queries. This mode cannot be used with a view containing joins.
+    Seek = u32::MAX,
+
+    /// Refreshes the information in the record. Must first call `fetch` on [`View`] with the same record.
+    /// Fails for a deleted row. Works with read-write and read-only records.
+    Refresh = 0,
+
+    /// Inserts a record. Fails if a row with the same primary keys exists. Fails with a read-only database.
+    /// This mode cannot be used with a view containing joins.
+    Insert = 1,
+
+    /// Updates an existing record. Non-primary keys only. Must first call `fetch` on [`View`].
+    /// Fails with a deleted record. Works only with read-write records.
+    Update = 2,
+
+    /// Writes current data in the cursor to a table row. Updates record if the primary keys match an existing row and inserts if they do not match.
+    /// Fails with a read-only database. This mode cannot be used with a view containing joins.
+    Assign = 3,
+
+    /// Updates or deletes and inserts a record into a table. Must first call `fetch` on [`View`] with the same record.
+    /// Updates record if the primary keys are unchanged. Deletes old row and inserts new if primary keys have changed. Fails with a read-only database.
+    /// This mode cannot be used with a view containing joins.
+    Replace = 4,
+
+    /// Inserts or validates a record in a table. Inserts if primary keys do not match any row and validates if there is a match.
+    /// Fails if the record does not match the data in the table. Fails if there is a record with a duplicate key that is not identical. Works only with read-write records.
+    /// This mode cannot be used with a view containing joins.
+    Merge = 5,
+
+    /// Remove a row from the table. You must first call the `fetch` on [`View`] function with the same record.
+    /// Fails if the row has been deleted. Works only with read-write records. This mode cannot be used with a view containing joins.
+    Delete = 6,
+
+    /// Inserts a temporary record. The information is not persistent. Fails if a row with the same primary key exists.
+    /// Works only with read-write records. This mode cannot be used with a view containing joins.
+    InsertTemporary = 7,
 }


### PR DESCRIPTION
This adds a crate-specific `Error` struct as well as a `CustomActionResult` that can be used for custom actions to simplify development.