### PR TITLE
Run cargo commands directly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,36 +31,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          # TODO: Remove duplicate configuration when https://github.com/actions-rs/toolchain/issues/126 is resolved.
-          components: cargo, clippy, rustfmt
-          override: true
-          toolchain: nightly
-          target: x86_64-pc-windows-msvc
+        run: rustup show
       - name: Check formatting
         if: ${{ success() && (inputs.full || github.event_name != 'workflow_call') }}
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          # Need to pass `--all-features` because of https://github.com/rust-lang/cargo/issues/2911.
-          args: --all-features --workspace
+        run: cargo test --all-features --workspace
       - name: Lint
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-features --all-targets --no-deps --workspace
+        run: cargo clippy --all-features --all-targets --no-deps --workspace
       - name: Build documentation
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --all-features --no-deps --workspace
+        run: cargo doc --all-features --no-deps --workspace
       - name: Set up MSBuild
         if: ${{ success() && (inputs.full || github.event_name != 'workflow_call') }}
         uses: microsoft/setup-msbuild@v1.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,16 +32,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
+        run: rustup show
       - name: Release
         run: gh release create ${{ github.ref_name }} --generate-notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish
-        uses: actions-rs/cargo@v1
-        with:
-          command: publish
+        run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,3 @@
-# Copyright 2022 Heath Stewart.
-# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
-
 [toolchain]
 channel = "nightly"
 components = ["cargo", "clippy", "rustfmt"]


### PR DESCRIPTION
Run `rustup show` to install from rust-toolchain.toml.
