### PR TITLE
Map any error to 1603

### DIFF
--- a/examples/skip/lib.rs
+++ b/examples/skip/lib.rs
@@ -17,7 +17,9 @@ pub extern "C" fn SkipExampleCustomAction(session: Session) -> CustomActionResul
         }
         true => {
             let data = session.property("CustomActionData")?;
-            if data == "2" {
+            // Unnecessarily parsing the string demonstrates using ? for any possible error.
+            let data = data.parse::<u32>()?;
+            if data == 2 {
                 return Skip;
             }
         }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -238,7 +238,7 @@ pub mod experimental {
     }
 
     impl FromResidual for CustomActionResult {
-        fn from_residual(residual: <Self as Try>::Residual) -> Self {
+        fn from_residual(residual: CustomActionResultCode) -> Self {
             match residual.0.into() {
                 ffi::ERROR_NO_MORE_ITEMS => CustomActionResult::Skip,
                 ffi::ERROR_INSTALL_USEREXIT => CustomActionResult::Cancel,
@@ -256,6 +256,12 @@ pub mod experimental {
                 ErrorKind::ErrorCode(code) => CustomActionResult::from(code.get()),
                 _ => CustomActionResult::Fail,
             }
+        }
+    }
+
+    impl<E: std::error::Error> FromResidual<std::result::Result<Infallible, E>> for CustomActionResult {
+        default fn from_residual(_: std::result::Result<Infallible, E>) -> Self {
+            CustomActionResult::Fail
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
 #![allow(dead_code)]
-#![cfg_attr(feature = "nightly", feature(try_trait_v2))]
+#![cfg_attr(feature = "nightly", feature(min_specialization, try_trait_v2))]
 #![doc = include_str!("../README.md")]
 
 // Fail fast on non-Windows platforms.


### PR DESCRIPTION
Without downcasting (expensive), there's no great way for a callee to return a non-fatal (still terminal) error code, though.
