### PR TITLE
Fix MSIHANDLE parameter modification in Rust 1.78.0+

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -15,9 +15,9 @@ impl Database {
     /// [SQL string](https://docs.microsoft.com/windows/win32/msi/sql-syntax).
     pub fn open_view(&self, sql: &str) -> Result<View> {
         unsafe {
-            let h = ffi::MSIHANDLE::null();
+            let mut h = ffi::MSIHANDLE::null();
             let sql = CString::new(sql)?;
-            let ret = ffi::MsiDatabaseOpenView(*self.h, sql.as_ptr(), &h);
+            let ret = ffi::MsiDatabaseOpenView(*self.h, sql.as_ptr(), &mut h);
             if ret != ffi::ERROR_SUCCESS {
                 return Err(
                     Error::from_last_error_record().unwrap_or_else(|| Error::from_error_code(ret))
@@ -34,9 +34,9 @@ impl Database {
     /// The field count of the record is the count of primary key columns.
     pub fn primary_keys(&self, table: &str) -> Result<Record> {
         unsafe {
-            let h = ffi::MSIHANDLE::null();
+            let mut h = ffi::MSIHANDLE::null();
             let table = CString::new(table)?;
-            let ret = ffi::MsiDatabaseGetPrimaryKeys(*self.h, table.as_ptr(), &h);
+            let ret = ffi::MsiDatabaseGetPrimaryKeys(*self.h, table.as_ptr(), &mut h);
             if ret != ffi::ERROR_SUCCESS {
                 return Err(Error::from_error_code(ret));
             }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -34,11 +34,15 @@ extern "C" {
     pub fn MsiDatabaseGetPrimaryKeys(
         hDatabase: MSIHANDLE,
         szTableName: LPCSTR,
-        hRecord: &MSIHANDLE,
+        hRecord: &mut MSIHANDLE,
     ) -> u32;
 
     #[link_name = "MsiDatabaseOpenViewA"]
-    pub fn MsiDatabaseOpenView(hDatabase: MSIHANDLE, szQuery: LPCSTR, phView: &MSIHANDLE) -> u32;
+    pub fn MsiDatabaseOpenView(
+        hDatabase: MSIHANDLE,
+        szQuery: LPCSTR,
+        phView: &mut MSIHANDLE,
+    ) -> u32;
 
     #[link_name = "MsiDoActionA"]
     pub fn MsiDoAction(hInstall: MSIHANDLE, szAction: LPCSTR) -> u32;
@@ -99,7 +103,7 @@ extern "C" {
 
     pub fn MsiViewExecute(hView: MSIHANDLE, hRecord: MSIHANDLE) -> u32;
 
-    pub fn MsiViewFetch(hView: MSIHANDLE, phRecord: &MSIHANDLE) -> u32;
+    pub fn MsiViewFetch(hView: MSIHANDLE, phRecord: &mut MSIHANDLE) -> u32;
 
     pub fn MsiViewModify(hView: MSIHANDLE, eModifyMode: ModifyMode, hRecord: MSIHANDLE) -> u32;
 }

--- a/src/view.rs
+++ b/src/view.rs
@@ -91,8 +91,8 @@ impl Iterator for View {
 
     fn next(&mut self) -> Option<Self::Item> {
         unsafe {
-            let h = ffi::MSIHANDLE::null();
-            ffi::MsiViewFetch(*self.h, &h);
+            let mut h = ffi::MSIHANDLE::null();
+            ffi::MsiViewFetch(*self.h, &mut h);
 
             if h.is_null() {
                 return None;


### PR DESCRIPTION
Rust 1.78.0 seems to have changed the behavior of passing references into FFI functions so that `mut` is required for it to be mutable. (I assume as it should have always done)

I was running into issues with the open_view command returning a null MSIHANDLE, when the MSI log shows that it should returning the newly created MSI handle from the OpenView call.

Changing the function signature to include `mut` makes my previously working pre-1.78.0 custom action work again in 1.78.0

Ran `cargo test --all-features` and all passed.